### PR TITLE
Update manifest.json to comply with HA requirement

### DIFF
--- a/custom_components/currentcost/manifest.json
+++ b/custom_components/currentcost/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "currentcost",
   "name": "Current Cost",
+  "version": "0.1.4",
   "documentation": "https://github.com/lolouk44/CurrentCost_HA_CC",
   "requirements": [
     "pyserial-asyncio==0.4",


### PR DESCRIPTION
Updated manifest.json to include "version". This is a requirement, integrations that do not include versions won't be allowed so this will stop working. I added   "version": "0.1.4", below the name. Please pull.