### PR TITLE
Solves #21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.5] - 2023-06-30
+### Changed
+- version bump pyserial-asyncio==0.6 to fix for python 3.11 in 2023.6
+
 ## [0.2.4] - 2023-01-14
 ### Added
 - Support for unique_id to help sensor customisation

--- a/custom_components/currentcost/manifest.json
+++ b/custom_components/currentcost/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.2.4",
   "documentation": "https://github.com/lolouk44/CurrentCost_HA_CC",
   "requirements": [
-    "pyserial-asyncio==0.4",
+    "pyserial-asyncio==0.6",
     "xmltodict==0.12.0"
   ],
   "dependencies": [],

--- a/custom_components/currentcost/manifest.json
+++ b/custom_components/currentcost/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "currentcost",
   "name": "Current Cost",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "documentation": "https://github.com/lolouk44/CurrentCost_HA_CC",
   "requirements": [
     "pyserial-asyncio==0.6",


### PR DESCRIPTION
See #21

version bump pyserial-asyncio==0.6 to fix for python 3.11 in 2023.6